### PR TITLE
armhf support

### DIFF
--- a/function/Dockerfile.armhf
+++ b/function/Dockerfile.armhf
@@ -1,0 +1,57 @@
+ARG RASPBIAN_VERSION=stretch
+FROM resin/rpi-raspbian:$RASPBIAN_VERSION
+
+# update apt
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends apt-utils \
+	# install necessary build tools \
+	&& apt-get -qy install build-essential cmake pkg-config unzip wget make \
+	# install necessary libraries \
+	&& apt-get -qy install \
+		libgtk2.0-dev \
+		libgtk-3-dev \
+		libatlas-base-dev \
+		gfortran \
+		python2.7-dev \
+		python3-dev \
+		python-pip \
+		python-numpy \
+		python3-pip \
+		python3-numpy \
+        python3-markdown \
+        python3-networkx \
+        python3-h5py \
+        python3-lxml \
+        python3-matplotlib \
+        python3-protobuf \
+        python3-dateutil \
+        python3-scipy \
+        python3-six \
+		libraspberrypi0 \
+		python-setuptools \
+		python3-setuptools \
+	# cleanup apt. \
+	&& apt-get purge -y --auto-remove \
+	&& rm -rf /var/lib/apt/lists/*
+
+WORKDIR /root/
+
+COPY requirements.txt ./
+
+RUN pip3 install -r requirements.txt
+
+RUN wget https://storage.googleapis.com/download.tensorflow.org/deps/pi/2018_03_22/tensorflow-1.6.0-cp35-none-any.whl 
+RUN pip3 install tensorflow-1.6.0-cp35-none-any.whl 
+
+ENV TF_CPP_MIN_LOG_LEVEL=3
+COPY *.py ./
+
+RUN python3 ./pre_download.py
+
+RUN curl -sSL https://github.com/openfaas/faas/releases/download/0.7.0/fwatchdog-armhf > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog
+
+ENV write_debug="true"
+ENV fprocess="python3 index.py"
+
+CMD ["fwatchdog"]

--- a/function/inception.py
+++ b/function/inception.py
@@ -585,5 +585,5 @@ def invoke(body):
 ########################################################################
 
 if __name__ == '__main__':
-	print(invoke())
+	print(invoke(os.path.join(data_dir, 'cropped_panda.jpg')))
 

--- a/function/pre_download.py
+++ b/function/pre_download.py
@@ -10,13 +10,7 @@
 # Copyright 2016 by Magnus Erik Hvass Pedersen
 #
 ########################################################################
-import json
-import numpy as np
-import tensorflow as tf
 import download
-from cache import cache
-import os
-import sys
 
 ########################################################################
 # Various directories and file-names.

--- a/function/requirements.txt
+++ b/function/requirements.txt
@@ -13,20 +13,27 @@
 # want to install the CPU or GPU version of TensorFlow.
 #
 ################################################################
-# Basic packages used in many of the tutorials.
+# Wheel needs to be installed directly for tensorflow installation to work
+wheel
 
-numpy
-scipy
-jupyter
-matplotlib
-Pillow
-scikit-learn
+
+# Basic packages used in many of the tutorials.
+# using apt for some like numpy and scipy, others skipping for the inception POC
+
+# numpy
+# scipy
+# jupyter
+# matplotlib
+# Pillow
+# scikit-learn
 
 ################################################################
 # TensorFlow can be installed either as CPU or GPU versions.
 # You select which one to install by (un)commenting these lines.
 
-tensorflow		# CPU Version of TensorFlow.
+# install with wheel file inside Dockerfile.armhf instead
+
+# tensorflow		# CPU Version of TensorFlow.
 # tensorflow-gpu	# GPU version of TensorFlow.
 
 # Builder API for TensorFlow used in many of the tutorials.
@@ -43,3 +50,6 @@ prettytensor
 http_parser
 
 requests
+
+# version locked tensorflow dependency
+grpcio==1.9.1


### PR DESCRIPTION
Adds Dockerfile.armhf with the dependencies needed to get tensorflow to work on armhf, and the watchdog to work for armhf.

Modifies inception.py to default execute the panda_jpeg example.

Modifies pre_download to eliminate all tf dependencies since they're not needed and will crash the docker build when you're not building on an rpi.

Modifies requirements.txt to only contain relevant packages, including a version locked grpc package needed for tensorflow. Everything else was moved into apt, some wheels weren't properly installing in docker.

Signed-off-by: tanuj <tanuj@spotai.co>